### PR TITLE
Fix Google Chrome video controls repeatedly resizing the video player

### DIFF
--- a/react/index.scss
+++ b/react/index.scss
@@ -152,6 +152,11 @@ img.logo {
 }
 .video-player {
 	width: 100%;
+	height: 100%;
+	background-color: #232323;
+}
+.video-player-wrapper {
+	width: 100%;
 	height: 82%;
 	background-color: #232323;
 }

--- a/react/js/components/Watch.jsx
+++ b/react/js/components/Watch.jsx
@@ -127,11 +127,13 @@ export default class Watch extends React.Component {
 					{episodes.length > 0 && <span>Episodes: {episodes}</span>}
 				</center>
 				</div>
-				<video ref={(i) => this.videoRef = i} className="video-player" controls poster="assets/logo-poster-dark.png">
-					{
-						selectedEpisode != null && <source type="video/mp4" src={"http://onepace.net/streams/" + selectedEpisode.crc32 + ".mp4"} />
-					}
-				</video>
+				<div className="video-player-wrapper">
+					<video ref={(i) => this.videoRef = i} className="video-player" controls poster="assets/logo-poster-dark.png">
+						{
+							selectedEpisode != null && <source type="video/mp4" src={"http://onepace.net/streams/" + selectedEpisode.crc32 + ".mp4"} />
+						}
+					</video>
+				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
#12 I've made a fix for the google chrome video player issue. I've just wrapped the video player in a div and applied the original video players' CSS to it. The div is unaffected by the video players controls popping in so hovering over it with this CSS doesn't cause the stuttering.