### PR TITLE
Remove max height attribute on sidebar

### DIFF
--- a/react/index.scss
+++ b/react/index.scss
@@ -60,7 +60,6 @@ li a:hover {
 	padding: 55px 15px 0 15px;
 	width: 300px;
 	min-height: 100%;
-	max-height: 100%;
 }
 .side-minimised {
 	background-color: #232323;
@@ -68,7 +67,6 @@ li a:hover {
 	padding: 55px 15px 0 15px;
 	width: 50px;
 	min-height: 100%;
-	max-height: 100%;
 }
 .side-toggle {
 	margin-top: 20px;


### PR DESCRIPTION
#16 My bad on this one. I added max-height to avoid horizontal scroll bars but I didn't realise it rendered this way on the about page.